### PR TITLE
Bugfix: Select Old Drivers would pick newest version

### DIFF
--- a/Rapr/Core/DSEForm.cs
+++ b/Rapr/Core/DSEForm.cs
@@ -476,7 +476,7 @@ namespace Rapr
 
                 lstDriverStoreEntries.CheckedObjects = driverStoreEntryList
                     .GroupBy(entry => new { entry.DriverClass, entry.DriverPkgProvider, entry.DriverInfName })
-                    .SelectMany(g => g.OrderByDescending(row => row.DriverDate).Skip(1))
+                    .SelectMany(g => g.OrderByDescending(row => row.DriverVersion).Skip(1))
                     .ToArray();
             }
         }


### PR DESCRIPTION
On scenarios where both drivers had the same date, RAPR could incorrecly choose the bigger version.

Bug found with the following drivers on my computer, where RAPR picked the bigger version instead of the smallest:

- prnms001.inf, 6.1.7600.16385, 21-06-2006, 298 KB
- prnms001.inf, 6.1.7601.17514, 21-06-2006, 299 KB