### PR TITLE
FIX - make HttpClient a single instance

### DIFF
--- a/Rapr/AboutBox.cs
+++ b/Rapr/AboutBox.cs
@@ -23,8 +23,8 @@ namespace Rapr
 
             try
             {
-                var result = getLatestVersion().GetAwaiter().GetResult();
-               
+                var result = GetLatestVersion().Result;
+
                 if (result?.Version != null)
                 {
                     if (AssemblyVersion >= result.Version)
@@ -58,7 +58,7 @@ namespace Rapr
             }
         }
 
-        private async Task<VersionInfo> getLatestVersion()
+        private async Task<VersionInfo> GetLatestVersion()
         {
             return await _updateManager.GetLatestVersionInfo().ConfigureAwait(false);
         }

--- a/Rapr/DSEForm.cs
+++ b/Rapr/DSEForm.cs
@@ -27,6 +27,8 @@ namespace Rapr
         private Color savedForeColor;
         private OperationContext context = new OperationContext();
 
+        private static readonly IUpdateManager _updateManager = new UpdateManager();
+
         private static readonly List<CultureInfo> SupportedLanguage = GetSupportedLanguage();
 
         public DSEForm()
@@ -532,12 +534,11 @@ namespace Rapr
                         break;
                 }
             }
-
         }
 
         private static void ShowAboutBox()
         {
-            using (AboutBox ab = new AboutBox())
+            using (AboutBox ab = new AboutBox(_updateManager))
             {
                 ab.ShowDialog();
             }

--- a/Rapr/IUpdateManager.cs
+++ b/Rapr/IUpdateManager.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Rapr
+{
+    public interface IUpdateManager
+    {
+        Task<VersionInfo> GetLatestVersionInfo();
+    }
+}

--- a/Rapr/Rapr.csproj
+++ b/Rapr/Rapr.csproj
@@ -98,6 +98,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="HttpClientExtensions.cs" />
     <Compile Include="IExport.cs" />
+    <Compile Include="IUpdateManager.cs" />
     <Compile Include="Lang\Language.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -122,6 +123,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\ConfigManager.cs" />
     <Compile Include="Utils\SetupAPI.cs" />
+    <Compile Include="VersionInfo.cs" />
     <EmbeddedResource Include="AboutBox.resx">
       <DependentUpon>AboutBox.cs</DependentUpon>
       <SubType>Designer</SubType>

--- a/Rapr/UpdateManager.cs
+++ b/Rapr/UpdateManager.cs
@@ -28,7 +28,8 @@ namespace Rapr
 
             if (response.IsSuccessStatusCode)
             {
-                var releaseInfo = JObject.Parse(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+                var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var releaseInfo = JObject.Parse(responseBody);
 
                 return new VersionInfo
                 {

--- a/Rapr/VersionInfo.cs
+++ b/Rapr/VersionInfo.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rapr
+{
+    public class VersionInfo
+    {
+        public Version Version { get; set; }
+        public Uri PageUrl { get; set; }
+        public Uri DownloadUrl { get; set; }
+    }
+}


### PR DESCRIPTION
Use this technique to stop the app creating a new connection pool each time the about window is opened, as per best practice for HttpClient.

For more information on why you should not use using with HttpClient please read https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/

Also converted the Version tuple to a single model class.