### PR TITLE
Ensure the window is on screen after restoring saved position

### DIFF
--- a/Rapr/DSEForm.cs
+++ b/Rapr/DSEForm.cs
@@ -281,10 +281,31 @@ namespace Rapr
             }
         }
 
+        private void EnsureOnScreen()
+        {
+            var workArea = Screen.GetWorkingArea(this);
+            var currentBounds = this.Bounds;
+            var newLocation = currentBounds.Location;
+
+            if (currentBounds.Right <= workArea.Left)
+                newLocation.X = workArea.Left;
+            else if (currentBounds.Left >= workArea.Right)
+                newLocation.X = workArea.Right - currentBounds.Width;
+
+            if (currentBounds.Bottom <= workArea.Top)
+                newLocation.Y = workArea.Top;
+            else if (currentBounds.Top >= workArea.Bottom)
+                newLocation.Y  = workArea.Bottom - currentBounds.Height;
+
+            this.Location = newLocation;
+        }
+
         private async void DSEForm_Shown(object sender, EventArgs e)
         {
             this.savedBackColor = this.lblStatus.BackColor;
             this.savedForeColor = this.lblStatus.ForeColor;
+
+            this.EnsureOnScreen();
 
             await this.PopulateUIWithDriverStoreEntries().ConfigureAwait(true);
         }


### PR DESCRIPTION
After restoring a saved location, the window may end up completely off-screen (e.g., after disconnecting a external monitor), which is confusing and annoying.
When this occurs, the window should be moved to the nearest screen so that it remains at least partially visible.
I'm not familiar with C# and WinForms, so feel free to correct me :)