### PR TITLE
update Microsoft.Dism to Version 6.0.0 and changed TargetFramework to net472

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Build & Test
 
-This is a .NET Framework 4.6.2 Windows Forms application. Use **MSBuild** (not `dotnet build`).
+This is a .NET Framework 4.7.2 Windows Forms application. Use **MSBuild** (not `dotnet build`).
 
 ```powershell
 # Restore + Build

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Driver Store Explorer (RAPR) is a powerful tool for viewing, managing, and clean
 
 ### Requirements
 - Windows 7 or newer
-- .NET Framework 4.6.2 or newer
+- .NET Framework 4.7.2 or newer
 - Administrator privileges
 
 ### Option 1: Download Pre-built Binary (Recommended)

--- a/README_KO.md
+++ b/README_KO.md
@@ -63,7 +63,7 @@ Driver Store Explorer (RAPR)는 Windows [드라이버 저장소](https://msdn.mi
 
 ### 요구 사항
 - Windows 7 이상
-- .NET Framework 4.6.2 이상
+- .NET Framework 4.7.2 이상
 - 관리자 권한
 
 ### 옵션 1: 사전 빌드된 바이너리 다운로드 (권장)

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -63,7 +63,7 @@ Driver Store Explorer (RAPR) 是一款功能强大的工具，用于查看、管
 
 ### 系统要求
 - Windows 7 或更高版本
-- .NET Framework 4.6.2 或更高版本
+- .NET Framework 4.7.2 或更高版本
 - 管理员权限
 
 ### 方式一：下载预编译版本（推荐）

--- a/README_ZH-TW.md
+++ b/README_ZH-TW.md
@@ -63,7 +63,7 @@ Driver Store Explorer (RAPR) 是一款功能強大的工具，用於檢視、管
 
 ### 系統需求
 - Windows 7 或更新版本
-- .NET Framework 4.6.2 或更新版本
+- .NET Framework 4.7.2 或更新版本
 - 系統管理員權限
 
 ### 方式一：下載預先建置版本（建議）

--- a/Rapr/Rapr.csproj
+++ b/Rapr/Rapr.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Dism" Version="5.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Dism" Version="6.0.0" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.WindowsAPICodePack.Core" Version="1.1.0" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.WindowsAPICodePack.Shell" Version="1.1.0" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" GeneratePathProperty="true" />
@@ -26,14 +26,13 @@
     <PackageReference Include="PortableSettingsProvider" Version="0.2.5" GeneratePathProperty="true" />
     <PackageReference Include="Resource.Embedder" Version="2.2.0" />
     <PackageReference Include="StrongNamer" Version="0.2.5" />
-    <PackageReference Include="System.ValueTuple" Version="4.6.2" GeneratePathProperty="true" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.configuration" />
     <Reference Include="System.Design" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="icon.ico" />
@@ -72,10 +71,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(PkgMicrosoft_Dism)\lib\net40\Microsoft.Dism.dll" Visible="false" />
+    <EmbeddedResource Include="$(PkgMicrosoft_Dism)\lib\net472\Microsoft.Dism.dll" Visible="false" />
     <EmbeddedResource Include="$(PkgNewtonsoft_Json)\lib\net45\Newtonsoft.Json.dll" Visible="false" />
     <EmbeddedResource Include="$(PkgObjectListView_Official)\lib\net20\ObjectListView.dll" Visible="false" />
-    <EmbeddedResource Include="$(PkgSystem_ValueTuple)\lib\net462\System.ValueTuple.dll" Visible="false" />
     <EmbeddedResource Include="$(PkgMicrosoft_WindowsAPICodePack_Core)\lib\Microsoft.WindowsAPICodePack.dll" Visible="false" />
     <EmbeddedResource Include="$(PkgMicrosoft_WindowsAPICodePack_Shell)\lib\Microsoft.WindowsAPICodePack.Shell.dll" Visible="false" />
     <EmbeddedResource Include="$(IntermediateOutputPath)SignedAssemblies\PortableSettingsProvider.dll" Visible="false">

--- a/Rapr/app.config
+++ b/Rapr/app.config
@@ -6,7 +6,7 @@
     </sectionGroup>
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
   </startup>
   <userSettings>
     <Rapr.Properties.Settings>

--- a/RaprTests/RaprTests.csproj
+++ b/RaprTests/RaprTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>Rapr.Tests</RootNamespace>


### PR DESCRIPTION
update Microsoft.Dism to Version 6.0.0 

 -> because `Microsoft.Dism` 6.0.0 only supports .net 4.7.2 I also changed `TargetFramework` to `net472`, removed no longer required reference `System.ValueTuple` as it is part of .net4.7.2 and changed all .md file to reflect change from 4.6.2 to 4.7.2 and I also had to change the `System.Net.Http` reference to PackageReference to avoid `System.IO.FileNotFoundException` (_Die Datei oder Assembly "System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" oder eine Abhängigkeit davon wurde nicht gefunden. Das System kann die angegebene Datei nicht finden._)

You need to decide if retargeting the framework version is ok skip newer versions of Microsoft.Dism. The new Async API is not related to driver calls from what I see.